### PR TITLE
feat: add a --strip flag, which strips whitespace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
 name = "bp"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "atty",
  "copypasta",

--- a/README.md
+++ b/README.md
@@ -67,11 +67,9 @@ bp | xxd | bp
 # copy some text with whitespace stripped
 echo " some text " | bp -s
 
-# copy the contents of `file.txt` with whitespace stripped
-bp -s file.txt
-
 # paste to standard output with whitespace stripped
 bp -s
+some text%
 ```
 
 ## Licence

--- a/README.md
+++ b/README.md
@@ -61,6 +61,19 @@ cat example.json | jq | bp | less
 bp | xxd | bp
 ```
 
+### Strip Whitespace
+
+```bash
+# copy some text with whitespace stripped
+echo " some text " | bp -s
+
+# copy the contents of `file.txt` with whitespace stripped
+bp -s file.txt
+
+# paste to standard output with whitespace stripped
+bp -s
+```
+
 ## Licence
 
 `bp` is available under the `GPL-3.0-or-later`.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ bp | bp
 # prettify, copy and view `example.json`
 cat example.json | jq | bp | less
 
+# edit your current clipboard
+bp | vipe | bp
+
 # hex-encode contents of the clipboard
 bp | xxd | bp
 ```

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -3,16 +3,24 @@ use std::io;
 
 use copypasta::{ClipboardContext, ClipboardProvider};
 
-pub fn copy(mut file: impl io::Read) -> Result<Vec<u8>, Error> {
+pub fn copy(mut file: impl io::Read, strip_whitespace: bool) -> Result<Vec<u8>, Error> {
     let mut ctx = ClipboardContext::new()?;
     let mut contents = Vec::with_capacity(32);
     file.read_to_end(&mut contents)?;
-    ctx.set_contents(String::from_utf8(contents.clone())?)?;
-    Ok(contents)
+
+    let mut contents = String::from_utf8(contents)?;
+    if strip_whitespace {
+        contents = contents.trim().to_string();
+    }
+    ctx.set_contents(contents.clone())?;
+    Ok(contents.into())
 }
 
-pub fn paste() -> Result<Vec<u8>, Error> {
+pub fn paste(strip_whitespace: bool) -> Result<Vec<u8>, Error> {
     let mut ctx = ClipboardContext::new()?;
-    let contents = ctx.get_contents()?.into_bytes();
-    Ok(contents)
+    let mut contents = ctx.get_contents()?;
+    if strip_whitespace {
+        contents = contents.trim().to_string();
+    }
+    Ok(contents.into_bytes())
 }


### PR DESCRIPTION
This PR adds a `--strip` / `-s` flag, which will remove leading and trailing whitespace from the content before copying or pasting.

This is particularly useful when looking to immediately paste content that has been copied from a shell command, for example:

```
echo "hello" | bp -s
```

Without `-s`, when the user presses Ctrl+V, "hello\n" is pasted, which often isn't the desired outcome.
